### PR TITLE
updating pins to bazel-toolchains and rules_docker to head

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -22,9 +22,9 @@ load(
 
 http_archive(
     name = "bazel_toolchains",
-    sha256 = "519231f32fb117c779d21ef9fb7530781cb2387ef53ebad751d6489ac1cab8a3",
-    strip_prefix = "bazel-toolchains-4b7be905026954c3ab3c294b53b623d3f141c11f",
-    urls = ["https://github.com/bazelbuild/bazel-toolchains/archive/4b7be905026954c3ab3c294b53b623d3f141c11f.tar.gz"],
+    sha256 = "e886e0624871dcce823cccc7f9a634c58b0d68fdc3ad6577347826558f1581d8",
+    strip_prefix = "bazel-toolchains-9f6cd65b5fd8bc85634dafc99075556c06d8d3a6",
+    urls = ["https://github.com/bazelbuild/bazel-toolchains/archive/9f6cd65b5fd8bc85634dafc99075556c06d8d3a6.tar.gz"],
 )
 
 http_archive(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -22,23 +22,23 @@ load(
 
 http_archive(
     name = "bazel_toolchains",
-    sha256 = "bcaa7239f4692054a7abcbcdb1f296f200cbe8a6c8c37bde485b3f3a0929a3c8",
-    strip_prefix = "bazel-toolchains-c6c7c4e850d9668d81aca2c7193b739755aa2fb5",
-    urls = ["https://github.com/bazelbuild/bazel-toolchains/archive/c6c7c4e850d9668d81aca2c7193b739755aa2fb5.tar.gz"],
+    sha256 = "b74b48aff73a8a9a2382404dd91d5a507762a9f7fa61772a9b8d06173b922370",
+    strip_prefix = "bazel-toolchains-add33a2bc6a7abb5ecca73cfdfea77a119007ba6",
+    urls = ["https://github.com/bazelbuild/bazel-toolchains/archive/add33a2bc6a7abb5ecca73cfdfea77a119007ba6.tar.gz"],
 )
 
 http_archive(
     name = "io_bazel_rules_docker",
-    sha256 = "aed1c249d4ec8f703edddf35cbe9dfaca0b5f5ea6e4cd9e83e99f3b0d1136c3d",
-    strip_prefix = "rules_docker-0.7.0",
-    urls = ["https://github.com/bazelbuild/rules_docker/archive/v0.7.0.tar.gz"],
+    sha256 = "17b31b680ada3290ebd03f0efdeb64d20c70aed7727b248a767a53cb015c0dbb",
+    strip_prefix = "rules_docker-8c8b973c15ea7690f4f888d1dd2bcdc92698c358",
+    urls = ["https://github.com/bazelbuild/rules_docker/archive/8c8b973c15ea7690f4f888d1dd2bcdc92698c358.tar.gz"],
 )
 
 http_archive(
     name = "base_images_docker",
-    sha256 = "26b6eb32e19deee8782bd734a2214c6a33dd5ec5b9fb3e92c69a2d5896ad89e3",
-    strip_prefix = "base-images-docker-6830adea69c63a5bf3cf8b93b2f5e56422181839",
-    urls = ["https://github.com/GoogleContainerTools/base-images-docker/archive/6830adea69c63a5bf3cf8b93b2f5e56422181839.tar.gz"],
+    sha256 = "d3df6bce618ed38b490ec1efcb9e45cedb4a832dc463a3a221aaa0078ded40e4",
+    strip_prefix = "base-images-docker-6a2b414ed6300a6847fe00a053e7e9df57d0a539",
+    urls = ["https://github.com/GoogleContainerTools/base-images-docker/archive/6a2b414ed6300a6847fe00a053e7e9df57d0a539.tar.gz"],
 )
 
 http_archive(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -22,23 +22,23 @@ load(
 
 http_archive(
     name = "bazel_toolchains",
-    sha256 = "b74b48aff73a8a9a2382404dd91d5a507762a9f7fa61772a9b8d06173b922370",
-    strip_prefix = "bazel-toolchains-add33a2bc6a7abb5ecca73cfdfea77a119007ba6",
-    urls = ["https://github.com/bazelbuild/bazel-toolchains/archive/add33a2bc6a7abb5ecca73cfdfea77a119007ba6.tar.gz"],
+    sha256 = "b3cddc03b828bcb6d2f969f738e2b13ef72d9889c24c10ca8113225fed02f84e",
+    strip_prefix = "bazel-toolchains-e08c7d2d38547b7b6c8aaa59d2d0d2684a77d22f",
+    urls = ["https://github.com/bazelbuild/bazel-toolchains/archive/e08c7d2d38547b7b6c8aaa59d2d0d2684a77d22f.tar.gz"],
 )
 
 http_archive(
     name = "io_bazel_rules_docker",
-    sha256 = "17b31b680ada3290ebd03f0efdeb64d20c70aed7727b248a767a53cb015c0dbb",
-    strip_prefix = "rules_docker-8c8b973c15ea7690f4f888d1dd2bcdc92698c358",
-    urls = ["https://github.com/bazelbuild/rules_docker/archive/8c8b973c15ea7690f4f888d1dd2bcdc92698c358.tar.gz"],
+    sha256 = "1a035f4e9c21e48668e09b327f89bd8197feb42b82d2b6904913c655f27a845a",
+    strip_prefix = "rules_docker-bb6d6606a6be348115af3552662799fd6d851a88",
+    urls = ["https://github.com/bazelbuild/rules_docker/archive/bb6d6606a6be348115af3552662799fd6d851a88.tar.gz"],
 )
 
 http_archive(
     name = "base_images_docker",
-    sha256 = "d3df6bce618ed38b490ec1efcb9e45cedb4a832dc463a3a221aaa0078ded40e4",
-    strip_prefix = "base-images-docker-6a2b414ed6300a6847fe00a053e7e9df57d0a539",
-    urls = ["https://github.com/GoogleContainerTools/base-images-docker/archive/6a2b414ed6300a6847fe00a053e7e9df57d0a539.tar.gz"],
+    sha256 = "16da54ef0734a0658d7006bc8bf6b9be26b963edec497b13974a1bfb46cefc41",
+    strip_prefix = "base-images-docker-7fdd2bb83a6957fe66712bd5238087b257b04378",
+    urls = ["https://github.com/GoogleContainerTools/base-images-docker/archive/7fdd2bb83a6957fe66712bd5238087b257b04378.tar.gz"],
 )
 
 http_archive(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -22,9 +22,9 @@ load(
 
 http_archive(
     name = "bazel_toolchains",
-    sha256 = "b3cddc03b828bcb6d2f969f738e2b13ef72d9889c24c10ca8113225fed02f84e",
-    strip_prefix = "bazel-toolchains-e08c7d2d38547b7b6c8aaa59d2d0d2684a77d22f",
-    urls = ["https://github.com/bazelbuild/bazel-toolchains/archive/e08c7d2d38547b7b6c8aaa59d2d0d2684a77d22f.tar.gz"],
+    sha256 = "519231f32fb117c779d21ef9fb7530781cb2387ef53ebad751d6489ac1cab8a3",
+    strip_prefix = "bazel-toolchains-4b7be905026954c3ab3c294b53b623d3f141c11f",
+    urls = ["https://github.com/bazelbuild/bazel-toolchains/archive/4b7be905026954c3ab3c294b53b623d3f141c11f.tar.gz"],
 )
 
 http_archive(

--- a/layers/ubuntu1404/base/revisions.bzl
+++ b/layers/ubuntu1404/base/revisions.bzl
@@ -16,5 +16,5 @@
 # TODO(xingao): make Dependency Update Service support containers not in GCR.
 
 IMAGE = struct(
-    sha256 = "sha256:cac55e5d97fad634d954d00a5c2a56d80576a08dcc01036011f26b88263f1578",
+    sha256 = "sha256:17f216e8eb523740f5f93a297faf6a6dcb393e14fa911168b4e9df3c0b6ef28e",
 )

--- a/layers/ubuntu1404/python/tests.yaml
+++ b/layers/ubuntu1404/python/tests.yaml
@@ -14,21 +14,14 @@
 
 schemaVersion: "2.0.0"
 
-# Python2 tests.
 commandTests:
+# Python2 tests.
 - name: 'python2-version'
   command: 'python'
   args: ['-V']
   # python outputs to stderr.
   expectedError: ['Python 2.7.*']
-
-fileExistenceTests:
-- name: 'Python2'
-  path: '/usr/bin/python2.7'
-  shouldExist: true
-
 # Python3 tests.
-commandTests:
 - name: 'python3-version'
   command: 'python3'
   args: ['-V']
@@ -39,6 +32,11 @@ commandTests:
   expectedOutput: ['Usage: apt-add-repository']
 
 fileExistenceTests:
+# Python2 tests.
+- name: 'Python2'
+  path: '/usr/bin/python2.7'
+  shouldExist: true
+# Python3 tests.
 - name: 'python3'
   path: '/usr/bin/python3'
   shouldExist: true

--- a/layers/ubuntu1604/go/BUILD
+++ b/layers/ubuntu1604/go/BUILD
@@ -34,7 +34,7 @@ language_tool_layer(
     base = "@ubuntu1604//image",
     env = {
         "GOPATH": "/go",
-        "PATH": "$PATH:/usr/local/go/bin",
+        "PATH": "$$PATH:/usr/local/go/bin",
     },
     tars = [":go_tar"],
 )

--- a/layers/ubuntu1604/python/tests.yaml
+++ b/layers/ubuntu1604/python/tests.yaml
@@ -14,21 +14,14 @@
 
 schemaVersion: "2.0.0"
 
-# Python2 tests.
 commandTests:
+# Python2 tests.
 - name: 'python2-version'
   command: 'python'
   args: ['-V']
   # python outputs to stderr.
   expectedError: ['Python 2.7.*']
-
-fileExistenceTests:
-- name: 'Python2'
-  path: '/usr/bin/python2.7'
-  shouldExist: true
-
 # Python3 tests.
-commandTests:
 - name: 'python3-version'
   command: 'python3'
   args: ['-V']
@@ -39,6 +32,11 @@ commandTests:
   expectedOutput: ['Usage: apt-add-repository']
 
 fileExistenceTests:
+# Python2 tests.
+- name: 'Python2'
+  path: '/usr/bin/python2.7'
+  shouldExist: true
+# Python3 tests.
 - name: 'python3'
   path: '/usr/bin/python3'
   shouldExist: true

--- a/layers/ubuntu1604/python_rbe/BUILD
+++ b/layers/ubuntu1604/python_rbe/BUILD
@@ -58,7 +58,7 @@ language_tool_layer(
     name = "python-rbe-ltl",
     base = "@ubuntu1604//image",
     env = {
-        "PATH": "$PATH:/opt/python3.6/bin",
+        "PATH": "$$PATH:/opt/python3.6/bin",
     },
     installables_tar = "@ubuntu1604_python_rbe_debs//file",
     installation_cleanup_commands = PYTHON_CLEANUP_COMMANDS,

--- a/layers/ubuntu1604/python_rbe/tests.yaml
+++ b/layers/ubuntu1604/python_rbe/tests.yaml
@@ -14,27 +14,26 @@
 
 schemaVersion: "2.0.0"
 
-# Python2 tests.
+
 commandTests:
+# Python2 tests.
 - name: 'python2-version'
   command: 'python'
   args: ['-V']
   # python outputs to stderr.
   expectedError: ['Python 2.7.*']
-
-fileExistenceTests:
-- name: 'Python2'
-  path: '/usr/bin/python2.7'
-  shouldExist: true
-
 # Python3 for RBE tests.
-commandTests:
 - name: 'python3-version'
   command: 'python3'
   args: ['-V']
   expectedOutput: ['Python 3.6.*']
 
 fileExistenceTests:
+# Python2 tests.
+- name: 'Python2'
+  path: '/usr/bin/python2.7'
+  shouldExist: true
+# Python3 for RBE tests.
 - name: 'python3'
   path: '/opt/python3.6/bin/python3'
   shouldExist: true


### PR DESCRIPTION
All upstream issues have been fixed and now we can update pins to all these repos.