### PR TITLE
Add libxcursor1 and libxcomposite1 as new dependencies to the android_test image, required by the Android emulator.

### DIFF
--- a/layers/ubuntu1604/android_test/BUILD
+++ b/layers/ubuntu1604/android_test/BUILD
@@ -47,6 +47,8 @@ download_pkgs(
         "lsof",
         "xvfb",
         "zlib1g:i386",
+        "libxcursor1",
+        "libxcomposite1",
     ],
 )
 

--- a/layers/ubuntu1604/android_test/BUILD
+++ b/layers/ubuntu1604/android_test/BUILD
@@ -44,11 +44,11 @@ download_pkgs(
         "cpio",
         "libpulse-dev",
         "libstdc++6:i386",
+        "libxcomposite1",
+        "libxcursor1",
         "lsof",
         "xvfb",
         "zlib1g:i386",
-        "libxcursor1",
-        "libxcomposite1",
     ],
 )
 


### PR DESCRIPTION
cc @smukherj1 @philwo