### PR TITLE
Update Python version ubuntu1804 Layer to 3.7

### DIFF
--- a/layers/ubuntu1804/python/BUILD
+++ b/layers/ubuntu1804/python/BUILD
@@ -38,7 +38,7 @@ download_pkgs(
     packages = [
         "python-dev",
         "python-setuptools",
-        "python3-dev",
+        "python3.7-dev",
         "software-properties-common",
     ],
 )


### PR DESCRIPTION
Switch from the `python3-dev` package to the `python3.7-dev` package. This will include a more recent version of python into the layer. More discussion is available on the bazel-dev@ list https://mail.google.com/mail/u/0/#inbox/FMfcgxwJXfnhxvJFvZQbltXPVjsJhVrM .

Possible warning: this may provide a different version of python during RBE and when running within the bazel docker container ( `l.gcr.io/google/bazel`).  This may introduce some strange things.