### PR TITLE
Update clang version from 11.0.0 to any arbitrary clang version

### DIFF
--- a/layers/ubuntu1604/clang/tests.yaml
+++ b/layers/ubuntu1604/clang/tests.yaml
@@ -18,7 +18,7 @@ commandTests:
 - name: 'clang-version'
   command: 'clang'
   args: ['--version']
-  expectedOutput: ['clang version 11.0.0']
+  expectedOutput: ['clang version [0-9]*\.[0-9]*\.[0-9]*']
 
 fileExistenceTests:
 - name: 'Clang'
@@ -32,39 +32,6 @@ fileExistenceTests:
   shouldExist: true
 - name: 'llvm-symbolizer'
   path: '/usr/local/bin/llvm-symbolizer'
-  shouldExist: true
-- name: 'sanitizer'
-  path: '/usr/local/lib/clang/11.0.0/include/sanitizer'
-  shouldExist: true
-- name: 'sanitizer-allocator'
-  path: '/usr/local/lib/clang/11.0.0/include/sanitizer/allocator_interface.h'
-  shouldExist: true
-- name: 'sanitizer-asan'
-  path: '/usr/local/lib/clang/11.0.0/include/sanitizer/asan_interface.h'
-  shouldExist: true
-- name: 'sanitizer-common_defs'
-  path: '/usr/local/lib/clang/11.0.0/include/sanitizer/common_interface_defs.h'
-  shouldExist: true
-- name: 'sanitizer-coverage'
-  path: '/usr/local/lib/clang/11.0.0/include/sanitizer/coverage_interface.h'
-  shouldExist: true
-- name: 'sanitizer-dfsan'
-  path: '/usr/local/lib/clang/11.0.0/include/sanitizer/dfsan_interface.h'
-  shouldExist: true
-- name: 'sanitizer-linux_syscall_hooks'
-  path: '/usr/local/lib/clang/11.0.0/include/sanitizer/linux_syscall_hooks.h'
-  shouldExist: true
-- name: 'sanitizer-lsan'
-  path: '/usr/local/lib/clang/11.0.0/include/sanitizer/lsan_interface.h'
-  shouldExist: true
-- name: 'sanitizer-msan'
-  path: '/usr/local/lib/clang/11.0.0/include/sanitizer/msan_interface.h'
-  shouldExist: true
-- name: 'sanitizer-tsan_atomic'
-  path: '/usr/local/lib/clang/11.0.0/include/sanitizer/tsan_interface_atomic.h'
-  shouldExist: true
-- name: 'sanitizer-tsan'
-  path: '/usr/local/lib/clang/11.0.0/include/sanitizer/tsan_interface.h'
   shouldExist: true
 
 metadataTest:

--- a/layers/ubuntu1804/clang/tests.yaml
+++ b/layers/ubuntu1804/clang/tests.yaml
@@ -18,7 +18,7 @@ commandTests:
 - name: 'clang-version'
   command: 'clang'
   args: ['--version']
-  expectedOutput: ['clang version 11.0.0']
+  expectedOutput: ['clang version [0-9]*\.[0-9]*\.[0-9]*']
 
 fileExistenceTests:
 - name: 'Clang'
@@ -32,39 +32,6 @@ fileExistenceTests:
   shouldExist: true
 - name: 'llvm-symbolizer'
   path: '/usr/local/bin/llvm-symbolizer'
-  shouldExist: true
-- name: 'sanitizer'
-  path: '/usr/local/lib/clang/11.0.0/include/sanitizer'
-  shouldExist: true
-- name: 'sanitizer-allocator'
-  path: '/usr/local/lib/clang/11.0.0/include/sanitizer/allocator_interface.h'
-  shouldExist: true
-- name: 'sanitizer-asan'
-  path: '/usr/local/lib/clang/11.0.0/include/sanitizer/asan_interface.h'
-  shouldExist: true
-- name: 'sanitizer-common_defs'
-  path: '/usr/local/lib/clang/11.0.0/include/sanitizer/common_interface_defs.h'
-  shouldExist: true
-- name: 'sanitizer-coverage'
-  path: '/usr/local/lib/clang/11.0.0/include/sanitizer/coverage_interface.h'
-  shouldExist: true
-- name: 'sanitizer-dfsan'
-  path: '/usr/local/lib/clang/11.0.0/include/sanitizer/dfsan_interface.h'
-  shouldExist: true
-- name: 'sanitizer-linux_syscall_hooks'
-  path: '/usr/local/lib/clang/11.0.0/include/sanitizer/linux_syscall_hooks.h'
-  shouldExist: true
-- name: 'sanitizer-lsan'
-  path: '/usr/local/lib/clang/11.0.0/include/sanitizer/lsan_interface.h'
-  shouldExist: true
-- name: 'sanitizer-msan'
-  path: '/usr/local/lib/clang/11.0.0/include/sanitizer/msan_interface.h'
-  shouldExist: true
-- name: 'sanitizer-tsan_atomic'
-  path: '/usr/local/lib/clang/11.0.0/include/sanitizer/tsan_interface_atomic.h'
-  shouldExist: true
-- name: 'sanitizer-tsan'
-  path: '/usr/local/lib/clang/11.0.0/include/sanitizer/tsan_interface.h'
   shouldExist: true
 
 metadataTest:


### PR DESCRIPTION
Also, removed the existence validation of the sanitizer directories, which contain the clang version.